### PR TITLE
Retry Logic

### DIFF
--- a/src/algorithm_testing.py
+++ b/src/algorithm_testing.py
@@ -25,7 +25,7 @@ def algorithm_publish(algo, payload):
         else:
             raise e
 
-def algorithm_test(algo, payload):
+def algorithm_test(algo, payload, retried=False):
     try:
         algo_info = algo.info()
         latest_hash = algo_info.version_info.git_hash
@@ -40,5 +40,8 @@ def algorithm_test(algo, payload):
             sleep(1)
             algorithm_test(algo, payload)
             return algo
+        elif not retried:
+            sleep(1)
+            algorithm_test(algo,payload, retried=True)
         else:
             raise e


### PR DESCRIPTION
Due to the non-deterministic effects our clusters may have on first runs of particular algorithms; this PR adds a retry system for all regular algorithms to verify that the algorithms can indeed execute.
This PR does not adjust the timeouts or add a retry for algorithms during the benchmark / testing phase; but we upon compilation or "readying" an algorithm in a particular workflow, we will now retry the sample input once if a timeout occurs before throwing an exception.